### PR TITLE
awesomewm: Setting to specify the prefix of the battery current and full charge path

### DIFF
--- a/awesomewm/README.md
+++ b/awesomewm/README.md
@@ -34,7 +34,6 @@ Configuration options
 ```lua
 assault({
    battery = "BAT0", -- battery ID to get data from
-   prefix = "energy", -- prefix of the current and full charge paths
    adapter = "AC", -- ID of the AC adapter to get data from
    width = 36, -- width of battery
    height = 15, -- height of battery

--- a/awesomewm/README.md
+++ b/awesomewm/README.md
@@ -34,6 +34,7 @@ Configuration options
 ```lua
 assault({
    battery = "BAT0", -- battery ID to get data from
+   prefix = "energy", -- prefix of the current and full charge paths
    adapter = "AC", -- ID of the AC adapter to get data from
    width = 36, -- width of battery
    height = 15, -- height of battery

--- a/awesomewm/assault.lua
+++ b/awesomewm/assault.lua
@@ -195,7 +195,7 @@ end
 function assault.new (args)
 	local args = args or {}
 	local battery = args.battery or 'BAT0'
-    local prefix = args.prefix or 'energy'
+	local prefix = args.prefix or 'energy'
 	local adapter = args.adapter or 'AC'
 	local stroke_width = args.stroke_width or 2
 	local width = args.width or 36
@@ -217,7 +217,7 @@ function assault.new (args)
 
 	data[widget] = {
 		battery = battery,
-        prefix = prefix,
+		prefix = prefix,
 		adapter = adapter,
 		width = width,
 		height = height,

--- a/awesomewm/assault.lua
+++ b/awesomewm/assault.lua
@@ -36,11 +36,11 @@ local acpi_battery_is_charging = function (battery)
 	return string.find(f:read(), 'Charging')
 end
 
-local acpi_battery_percent = function (battery)
-	local f = io.open('/sys/class/power_supply/' .. battery .. '/energy_now')
+local acpi_battery_percent = function (battery, prefix)
+	local f = io.open('/sys/class/power_supply/' .. battery .. '/' .. prefix .. '_now')
 	if f == nil then return 0 end
 	local now = tonumber(f:read())
-	local full = tonumber(io.open('/sys/class/power_supply/' .. battery .. '/energy_full'):read())
+	local full = tonumber(io.open('/sys/class/power_supply/' .. battery .. '/' .. prefix .. '_full'):read())
 	return now / full
 end
 
@@ -133,7 +133,7 @@ local battery_fill_generate = function (width, height, percent)
 end
 
 local properties = {
-	"battery", "adapter", "width", "height", "peg_top",
+	"battery", "prefix", "adapter", "width", "height", "peg_top",
 	"peg_height", "peg_width", "stroke_width",
 	"font", "critical_level",
 	"normal_color", "charging_color", "critical_color"
@@ -153,7 +153,7 @@ function assault.draw (assault, wibox, cr, width, height)
 	}))
 
 	cr.fill_rule = "EVEN_ODD"
-	local percent = acpi_battery_percent(data[assault].battery)
+	local percent = acpi_battery_percent(data[assault].battery, data[assault].prefix)
 
 	local draw_color = color(data[assault].normal_color)
 	if acpi_battery_is_charging(data[assault].battery) then
@@ -195,6 +195,7 @@ end
 function assault.new (args)
 	local args = args or {}
 	local battery = args.battery or 'BAT0'
+    local prefix = args.prefix or 'energy'
 	local adapter = args.adapter or 'AC'
 	local stroke_width = args.stroke_width or 2
 	local width = args.width or 36
@@ -216,6 +217,7 @@ function assault.new (args)
 
 	data[widget] = {
 		battery = battery,
+        prefix = prefix,
 		adapter = adapter,
 		width = width,
 		height = height,

--- a/awesomewm/assault.lua
+++ b/awesomewm/assault.lua
@@ -44,21 +44,12 @@ local acpi_battery_is_charging = function (battery)
 end
 
 local acpi_battery_percent = function (battery)
-	local f = io.open('/sys/class/power_supply/' .. battery .. '/energy_now')
-	if f ~= nil then
-		local now = tonumber(f:read())
-		local full = tonumber(io.open('/sys/class/power_supply/' .. battery .. '/energy_full'):read())
-		return now / full
-	end
-
-	f = io.open('/sys/class/power_supply/' .. battery .. '/charge_now')
-	if f ~= nil then
-		local now = tonumber(f:read())
-		local full = tonumber(io.open('/sys/class/power_supply/' .. battery .. '/charge_full'):read())
-		return now / full
-	end
-
-	return 0
+	local now  = io.open('/sys/class/power_supply/' .. battery .. '/energy_now') or
+		     io.open('/sys/class/power_supply/' .. battery .. '/charge_now')
+	local full = io.open('/sys/class/power_supply/' .. battery .. '/energy_full') or
+		     io.open('/sys/class/power_supply/' .. battery .. '/charge_full')
+	if (now == nil) or (full == nil) then return 0 end
+	return tonumber(now:read())/tonumber(full:read())
 end
 
 local battery_bolt_generate = function (width, height)


### PR DESCRIPTION
In my case, the battery charge paths where named "charge_now" and "charge_full" rather than "energy_now" and "energy_full". This change enables the user to set their own prefix if it is needed.